### PR TITLE
Bump version to 2.1.7 for 1877.15

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 debian_version="1.7.24_ds1-10"
-version_orig="2.1.6"
+version_orig="2.1.7"
 version="${version_orig}-0"
 
-version_suffix=gl3~bp1877
+version_suffix=gl0~bp1877
 
 DEBIAN_SRC=$(mktemp -d)
 git clone -b "debian/$debian_version" --depth=1 https://salsa.debian.org/go-team/packages/containerd.git $DEBIAN_SRC


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the containerd version to 2.1.7 for 1877.15.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4666
