### PR TITLE
Bump to version 2.2.3

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
 debian_version="1.7.24_ds1-6"
-version_orig="2.2.2"
+version_orig="2.2.3"
 version="${version_orig}-0"
 
 DEBIAN_SRC=$(mktemp -d)


### PR DESCRIPTION
**What this PR does / why we need it**:
Update to version `2.2.3` for the nightly.

**Which issue(s) this PR fixes**:
Part of [#4665](https://github.com/gardenlinux/gardenlinux/issues/4665)
